### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-full-sync.yml
+++ b/.github/workflows/azure-full-sync.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: "Full sync of Azure resources to Port"
 on:
   workflow_dispatch:

--- a/.github/workflows/azure-incremental-sync.yml
+++ b/.github/workflows/azure-incremental-sync.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: write
 name: "Incremental sync of Azure resources to Port"
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/v1vhm/port-setup/security/code-scanning/5](https://github.com/v1vhm/port-setup/security/code-scanning/5)

To fix the problem, add an explicit `permissions` block to the workflow. This can be done at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). Since there is only one job (`sync`), either location is acceptable, but adding it at the workflow level is clearer and future-proof. The workflow needs `contents: write` permission for the `git push` step, and no other special permissions are required. Therefore, add the following block near the top of the file, after the `name` field and before the `on` field:

```yaml
permissions:
  contents: write
```

No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
