### PR TITLE
fix: use timezone-aware datetime in incremental sync workflow

### DIFF
--- a/.github/workflows/azure-incremental-sync.yml
+++ b/.github/workflows/azure-incremental-sync.yml
@@ -43,7 +43,7 @@ jobs:
               ts = data.get("last_recorded_change")
               if ts:
                 last = datetime.datetime.fromisoformat(ts.replace("Z","+00:00"))
-                now = datetime.datetime.utcnow()
+                now = datetime.datetime.now(datetime.UTC)
                 minutes = int((now - last).total_seconds() / 60) + 2
               else:
                 minutes = default
@@ -91,7 +91,7 @@ jobs:
           import json, os, datetime, pathlib
           status_file = pathlib.Path("repo/.github/run-status.json")
           status_file.parent.mkdir(parents=True, exist_ok=True)
-          now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+          now = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
           data = {
             "run_start": os.environ["RUN_START"],
             "run_finish": now,


### PR DESCRIPTION
## Summary
- use timezone-aware datetime in minutes calculation
- timestamp run-status updates with UTC aware datetime

## Testing
- `yamllint -d "{extends: default, rules: {line-length: {max: 120}, document-start: disable, truthy: disable}}" .github/workflows/azure-incremental-sync.yml && echo 'yamllint: OK'`


------
https://chatgpt.com/codex/tasks/task_e_68a2bcfb646c8330bbd049b1bc3faf14